### PR TITLE
Send a clean hit from the Thank You page

### DIFF
--- a/website/scripts/thank-you-page.js
+++ b/website/scripts/thank-you-page.js
@@ -2,6 +2,9 @@
 ---
 {% if jekyll.environment == "production" %}
 $(function(){
+    gtag('config', window.GA_PROPERTY_ID, {
+        'page_path': '/thanks-for-downloading-ctp'
+    });
     $('#download-problem').on('click', function () {
         gtag('config', window.GA_PROPERTY_ID, {
             'page_path': '/thanks-report-download-problem'


### PR DESCRIPTION
\cc @kirovboris 

After we added a query string parameter to the Thank You page link, GA sends a hit from `/thanks-for-downloading-ctp/?downloadLink=https://go.devexpress.com/DevExpressDownload_TestCafeStudio_Win.aspx`, while Natalie needs a hit from just `/thanks-for-downloading-ctp`