### PR TITLE
Rename the Images folder in gulpfile

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -134,7 +134,17 @@ function buildWebsite (mode, cb) {
 // * Google Analytics is enabled in production mode only.
 
 gulp.task('build-website-production', ['prepare-website'], function (cb) {
-    buildWebsite('production', cb);
+    return new Promise(function (resolve) {
+        buildWebsite('production', resolve);
+    })
+    .then( function () {
+        // NOTE: Jekyll generates a folder named 'Images' 
+        // starting from the capital letter (for some reason).
+        // This is a quick fix for this.
+        return new Promise(function (resolve) {
+            fs.rename('site/deploy/Images', 'site/deploy/images', resolve);
+        });
+    });
 });
 
 gulp.task('build-website-development', ['prepare-website'], function (cb) {


### PR DESCRIPTION
\cc @kirovboris @helen-dikareva 

When Jekyll receives the `images` folder in the website sources, it generates the `Images` folder (with the capital `I`) in the output.

I somehow fixed this for the open-source site but I can't remember how. So I'm just going to rename the folder after build. If you think this is a very dirty fix, don't merge this because **for now we are hosted on a Windows server with case-insensitive paths**. And this fix is not required.